### PR TITLE
Adds a ref to hook into the original instance method.

### DIFF
--- a/src/hook.js
+++ b/src/hook.js
@@ -72,7 +72,10 @@ export default function hook(WrappedComponent) {
     }
 
     render() {
-      return <WrappedComponent generateTestHook={this.generateTestHook} {...this.props} />;
+      return <WrappedComponent
+        ref={c => this._instance = c}
+        generateTestHook={this.generateTestHook} {...this.props}
+      />;
     }
   };
 


### PR DESCRIPTION
**The problem**
We need to call an instance method from a parent, but when the comonent is wrapped in a `hook()` you can't access the original instance.

**The solution** 
This adds a ref to the original instance so now what would original throw an error after wrapping in a hook. You can change the code

```
cameraView.capture();
```
to
```
cameraView._instance.capture();
```